### PR TITLE
Update unit range and UI layout adjustments

### DIFF
--- a/Chrauma Tactics/Assets/Prefabs/Scene/--- Managers ---.prefab
+++ b/Chrauma Tactics/Assets/Prefabs/Scene/--- Managers ---.prefab
@@ -416,7 +416,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d5a57f767e5e46a458fc5d3c628d0cbb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  GlobalObjectIdHash: 0
+  GlobalObjectIdHash: 1757260259
   InScenePlacedSourceGlobalObjectIdHash: 0
   DeferredDespawnTick: 0
   Ownership: 1

--- a/Chrauma Tactics/Assets/Prefabs/Units/Unit/Strikers.prefab
+++ b/Chrauma Tactics/Assets/Prefabs/Units/Unit/Strikers.prefab
@@ -177,7 +177,7 @@ MonoBehaviour:
   _baseAtk: 20
   _baseMoveSpeed: 8
   _baseAtkSpeed: 1.6
-  _baseRange: 25
+  _baseRange: 26
   SpawnPosition: {x: 0, y: 0, z: 0}
   _hasSmoothStop: 0
   _decelerationRate: 2.5

--- a/Chrauma Tactics/Assets/Scenes/SampleScene.unity
+++ b/Chrauma Tactics/Assets/Scenes/SampleScene.unity
@@ -175,6 +175,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9068507399604067786, guid: b2e66ceb523f6cc40b1c72db7f2db78f, type: 3}
+      propertyPath: GlobalObjectIdHash
+      value: 1757260259
+      objectReference: {fileID: 0}
+    - target: {fileID: 9068507399604067786, guid: b2e66ceb523f6cc40b1c72db7f2db78f, type: 3}
+      propertyPath: SceneMigrationSynchronization
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -530,7 +538,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5329968684652311227, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 709.8424
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5469490378776601465, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
       propertyPath: m_AnchorMax.y
@@ -607,6 +615,22 @@ PrefabInstance:
     - target: {fileID: 7764068309674618332, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7839373324488614830, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7839373324488614830, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7839373324488614830, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7839373324488614830, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8218538435362790114, guid: 54a90ad0503cf4b6495146f0e8002192, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1142,10 +1166,6 @@ PrefabInstance:
     - target: {fileID: 8283380237587150954, guid: d9ada3c1604384c4da82b6bfcc4a8eb3, type: 3}
       propertyPath: m_Name
       value: -- Commander Select --
-      objectReference: {fileID: 0}
-    - target: {fileID: 8283380237587150954, guid: d9ada3c1604384c4da82b6bfcc4a8eb3, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Chrauma Tactics/Assets/Scripts/UI/UnitSelectionUI/UnitUISelector.cs
+++ b/Chrauma Tactics/Assets/Scripts/UI/UnitSelectionUI/UnitUISelector.cs
@@ -22,6 +22,8 @@ namespace CT.UI.UnitSelectionUI
         private int _cost;
         public Team Team = Team.Player1;
 
+        
+
         #region Unity Methods
         private void Awake()
         {


### PR DESCRIPTION
Increased Striker unit base range from 25 to 26. Adjusted UI element positions and scaling in SampleScene, including changes to anchored positions and local scale. Updated GlobalObjectIdHash in manager prefab for consistency. Minor formatting change in UnitUISelector.cs.